### PR TITLE
Interpolate request proto in request header

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,8 @@ lint:  ## Lint go source code
 
 protos:
 	protoc \
-		--go_out=. --go-grpc_out=. \
-		--go_opt=module=foxygo.at/protog --go-grpc_opt=module=foxygo.at/protog \
+		--go_out=. --go_opt=module=foxygo.at/protog  \
+		--go-grpc_out=. --go-grpc_opt=module=foxygo.at/protog \
 		-I httprule/internal \
 		test.proto echo.proto
 	goimports -w .


### PR DESCRIPTION
Interpolate request proto in request header, specified via additional
bindings. This is a deviation from the spec but seems like a useful
enhancement to retrofit proto definitions for exisiting HTTP/JSON
APIs.

Minor Makefile fix around protoc flag ordering.