### PR TITLE
Add HEAD HTTP request handling

### DIFF
--- a/httprule/httprule.go
+++ b/httprule/httprule.go
@@ -473,6 +473,8 @@ func templatePath(rule *pb.HttpRule) string {
 		return rule.GetPost()
 	case rule.GetDelete() != "":
 		return rule.GetDelete()
+	case rule.GetCustom() != nil && rule.GetCustom().GetKind() == "HEAD":
+		return rule.GetCustom().GetPath()
 	}
 	return ""
 }
@@ -489,6 +491,8 @@ func method(rule *pb.HttpRule) string {
 		return http.MethodDelete
 	case rule.GetPatch() != "":
 		return http.MethodPatch
+	case rule.GetCustom() != nil && rule.GetCustom().GetKind() == "HEAD":
+		return http.MethodHead
 	}
 	return ""
 }

--- a/httprule/httprule_test.go
+++ b/httprule/httprule_test.go
@@ -383,6 +383,13 @@ func TestNewHTTPRequest(t *testing.T) {
 			pbReq:      &internal.TestMessage1{Field1: "val1"},
 			wantMethod: "DELETE",
 			wantURL:    u1 + "/v1/val1"},
+		"head_method": {
+			rule:       customRule("HEAD", "v1"),
+			baseURL:    u1,
+			pbReq:      &internal.TestMessage1{},
+			wantMethod: "HEAD",
+			wantURL:    u1 + "/v1",
+		},
 		"path_and_query": {
 			rule:       &pb.HttpRule{Pattern: &pb.HttpRule_Post{Post: "v1/{weird_FieldName_1_=*}/bool/{a_bool2}"}},
 			baseURL:    u3,
@@ -482,14 +489,7 @@ func TestNewHTTPRequest(t *testing.T) {
 				Pattern: &pb.HttpRule_Post{Post: "/"},
 				Body:    "field3_sub",
 				AdditionalBindings: []*pb.HttpRule{
-					{
-						Pattern: &pb.HttpRule_Custom{
-							Custom: &pb.CustomHttpPattern{
-								Kind: "header",
-								Path: "field2: {field2}",
-							},
-						},
-					},
+					customRule("header", "field2: {field2}"),
 				},
 			},
 			baseURL: u3,
@@ -584,14 +584,7 @@ func TestNewHTTPRequestErr(t *testing.T) {
 			rule: &pb.HttpRule{
 				Pattern: &pb.HttpRule_Post{Post: "v1/{field1}"},
 				AdditionalBindings: []*pb.HttpRule{
-					{
-						Pattern: &pb.HttpRule_Custom{
-							Custom: &pb.CustomHttpPattern{
-								Kind: "header",
-								Path: "field1: {field1}",
-							},
-						},
-					},
+					customRule("header", "field: {field1}"),
 				},
 			},
 			baseURL: u,


### PR DESCRIPTION
Handle the HEAD HTTP method by using a Custom pattern in the HttpRule
with the kind of `HEAD`. Issue a HTTP HEAD request when this pattern is
presented.