### PR TITLE
Add --zero flag for JSON output

### DIFF
--- a/cmd/pb/main.go
+++ b/cmd/pb/main.go
@@ -67,7 +67,7 @@ func run(cfg PBConfig) error {
 	}
 	unmarshal, err := cfg.unmarshaler()
 	if err != nil {
-		return err
+		return fmt.Errorf("cannot decode %q input: %w", cfg.inFormat(), err)
 	}
 	message := dynamicpb.NewMessage(md)
 	if err := unmarshal(in, message); err != nil {
@@ -106,8 +106,7 @@ func (c *PBConfig) writeOutput(b []byte) error {
 }
 
 func (c *PBConfig) unmarshaler() (unmarshaler, error) {
-	format := getFormat(c.In, c.InFormat)
-	switch format {
+	switch c.inFormat() {
 	case "json":
 		o := protojson.UnmarshalOptions{Resolver: c.Protoset}
 		return o.Unmarshal, nil
@@ -118,7 +117,11 @@ func (c *PBConfig) unmarshaler() (unmarshaler, error) {
 		o := prototext.UnmarshalOptions{Resolver: c.Protoset}
 		return o.Unmarshal, nil
 	}
-	return nil, fmt.Errorf("unknown input format %s", format)
+	return nil, fmt.Errorf("unknown input format %q", c.inFormat())
+}
+
+func (c *PBConfig) inFormat() string {
+	return getFormat(c.In, c.InFormat)
 }
 
 func (c *PBConfig) marshaler() (marshaler, error) {

--- a/cmd/pb/main.go
+++ b/cmd/pb/main.go
@@ -20,9 +20,11 @@ import (
 )
 
 var (
-	version     = "tip"
-	commit      = "HEAD"
-	date        = "now"
+	// version vars set by goreleaser
+	version = "tip"
+	commit  = "HEAD"
+	date    = "now"
+
 	description = `
 pb translates encoded Protobuf message from one format to another
 `

--- a/cmd/pb/main.go
+++ b/cmd/pb/main.go
@@ -37,7 +37,7 @@ pb translates encoded Protobuf message from one format to another
 type PBConfig struct {
 	Protoset    *registry.Files `short:"P" help:"Protoset of Message being translated" required:""`
 	Out         string          `short:"o" help:"Output file name"`
-	InFormat    string          `short:"I" help:"Input format (json, pb)" enum:"json,pb,j,p," default:""`
+	InFormat    string          `short:"I" help:"Input format (j[son], p[b],t[xt])" enum:"json,pb,txt,j,p,t," default:""`
 	OutFormat   string          `short:"O" help:"Output format (j[son], p[b],t[xt])" enum:"json,pb,txt,j,p,t," default:""`
 	MessageType string          `arg:"" help:"Message type to be translated" required:""`
 	In          string          `arg:"" help:"Message value JSON encoded" optional:""`

--- a/cmd/pb/testdata/pbtest.pb
+++ b/cmd/pb/testdata/pbtest.pb
@@ -1,12 +1,5 @@
 
-–
-pbtest.protopbtest"&
+;
+pbtest.protopbtest"
 BaseMessage
-f (	Rf*	è€€€€"­
-ExtensionMessage
-f (	RfI
-NestedExtension
-nf (	Rnf2&
-ef3.pbtest.BaseMessageë (	Ref32@
-ef2.pbtest.BaseMessageê (2.pbtest.ExtensionMessageRef2:&
-ef1.pbtest.BaseMessageé (	Ref1
+f (	Rfbproto3

--- a/cmd/pb/testdata/pbtest.proto
+++ b/cmd/pb/testdata/pbtest.proto
@@ -1,33 +1,8 @@
-syntax = "proto2";
+syntax = "proto3";
 
 package pbtest;
 
 // A base message to be extended
 message BaseMessage {
-  optional string f = 1;
-  extensions 1000 to max;
-}
-
-// A simple top-level extension
-extend BaseMessage {
-  optional string ef1 = 1001;
-}
-
-// A message scope for more extensions
-message ExtensionMessage {
-  optional string f = 1;
-
-  // An extension scoped within a message
-  extend BaseMessage {
-    optional ExtensionMessage ef2 = 1002;
-  };
-
-  message NestedExtension {
-    optional string nf = 1;
-
-    // An extension scoped within a nested message
-    extend BaseMessage {
-      optional string ef3 = 1003;
-    };
-  };
+  string f = 1;
 }


### PR DESCRIPTION
Add `--zero` flag for JSON output, so that optionally `""`, `false`, `null`, `0` for
non-optional proto3 fields are printed.

Minor bugfixes and non-functional changes:

* Fix `--in-format` to accept `txt`
* Improve error message for when input cannot be parsed
* Add goreleaser comment for main.go global vars