### PR TITLE
pb: Add --descriptorpb/-D flag for easy decoding of descriptor pbs

### DIFF
--- a/proto/google/protobuf/descriptor.proto
+++ b/proto/google/protobuf/descriptor.proto
@@ -740,8 +740,8 @@ message UninterpretedOption {
   // The name of the uninterpreted option.  Each string represents a segment in
   // a dot-separated name.  is_extension is true iff a segment represents an
   // extension (denoted with parentheses in options specs in .proto files).
-  // E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
-  // "foo.(bar.baz).qux".
+  // E.g.,{ ["foo", false], ["bar.baz", true], ["moo", false] } represents
+  // "foo.(bar.baz).moo".
   message NamePart {
     required string name_part = 1;
     required bool is_extension = 2;
@@ -868,13 +868,13 @@ message SourceCodeInfo {
     //   // Comment attached to baz.
     //   // Another line attached to baz.
     //
-    //   // Comment attached to qux.
+    //   // Comment attached to moo.
     //   //
-    //   // Another line attached to qux.
-    //   optional double qux = 4;
+    //   // Another line attached to moo.
+    //   optional double moo = 4;
     //
     //   // Detached comment for corge. This is not leading or trailing comments
-    //   // to qux or corge because there are blank lines separating it from
+    //   // to moo or corge because there are blank lines separating it from
     //   // both.
     //
     //   // Detached comment for corge paragraph 2.


### PR DESCRIPTION
Add a `--descriptorpb`/`-D` flag that specifies that descriptorpb should
be used as the `FileDescriptorSet` instead of requiring it to be
specified on the command line. This makes `--protoset`/`-P` not required
in this case.

This makes it easy to inspect what `protoc` produces:

    protoc -o/dev/stdout foo.proto | pb -D

This will show the descriptorpb form of `foo.proto` in JSON (or add
`-Ot` to see it in prototext format, which is a bit more compact).