### PR TITLE
Decode all well-known types without needing a descriptor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ lint:  ## Lint go source code
 proto:
 	protosync --dest proto google/api/annotations.proto
 	protoc -I cmd/pb/testdata --include_imports -o cmd/pb/testdata/pbtest.pb cmd/pb/testdata/pbtest.proto
+	protoc -I cmd/pb/testdata -o cmd/pb/testdata/options.pb cmd/pb/testdata/options.proto
 	protoc -I proto -I registry/testdata --include_imports -o registry/testdata/regtest.pb registry/testdata/regtest.proto
 	protoc -I proto -I httprule/internal --go_out=. --go_opt=module=foxygo.at/protog --go-grpc_out=. --go-grpc_opt=module=foxygo.at/protog test.proto echo.proto
 	gosimports -w .

--- a/cmd/pb/main.go
+++ b/cmd/pb/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -16,8 +15,19 @@ import (
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
 	"google.golang.org/protobuf/types/descriptorpb"
-	"google.golang.org/protobuf/types/dynamicpb"
+	_ "google.golang.org/protobuf/types/known/anypb"
+	_ "google.golang.org/protobuf/types/known/apipb"
+	_ "google.golang.org/protobuf/types/known/durationpb"
+	_ "google.golang.org/protobuf/types/known/emptypb"
+	_ "google.golang.org/protobuf/types/known/fieldmaskpb"
+	_ "google.golang.org/protobuf/types/known/sourcecontextpb"
+	_ "google.golang.org/protobuf/types/known/structpb"
+	_ "google.golang.org/protobuf/types/known/timestamppb"
+	_ "google.golang.org/protobuf/types/known/typepb"
+	_ "google.golang.org/protobuf/types/known/wrapperspb"
+	_ "google.golang.org/protobuf/types/pluginpb"
 )
 
 var (
@@ -36,21 +46,23 @@ pb translates encoded Protobuf message from one format to another
 )
 
 type PBConfig struct {
-	Protoset     *registry.Files `short:"P" help:"Protoset of Message being translated" xor:"protoset"`
-	Descriptorpb bool            `short:"D" help:"Use descriptorpb as protoset" xor:"protoset"`
-	Out          string          `short:"o" help:"Output file name"`
-	InFormat     string          `short:"I" help:"Input format (j[son], p[b], t[xt])" enum:"json,pb,txt,j,p,t," default:""`
-	OutFormat    string          `short:"O" help:"Output format (j[son], p[b], t[xt])" enum:"json,pb,txt,j,p,t," default:""`
-	Zero         bool            `short:"z" help:"Print zero values in JSON output"`
-	MessageType  string          `arg:"" help:"Message type to be translated" optional:""`
-	In           string          `arg:"" help:"Message value JSON encoded" optional:""`
+	Protoset *descriptorpb.FileDescriptorSet `short:"P" help:"Protoset containing Message to be translated"`
+
+	Out         string `short:"o" help:"Output file name"`
+	InFormat    string `short:"I" help:"Input format (j[son], p[b], t[xt])" enum:"json,pb,txt,j,p,t," default:""`
+	OutFormat   string `short:"O" help:"Output format (j[son], p[b], t[xt])" enum:"json,pb,txt,j,p,t," default:""`
+	Zero        bool   `short:"z" help:"Print zero values in JSON output"`
+	MessageType string `arg:"" help:"Message type to be translated"`
+	In          string `arg:"" help:"Message value JSON encoded" optional:""`
+
+	types *protoregistry.Types
 }
 
 func main() {
 	kctx := kong.Parse(&cli,
 		kong.Description(description),
 		kong.Vars{"version": fmt.Sprintf("%s (%s on %s)", version, commit, date)},
-		kong.TypeMapper(reflect.TypeOf(cli.PBConfig.Protoset), kong.MapperFunc(registryMapper)),
+		kong.TypeMapper(reflect.TypeOf(cli.PBConfig.Protoset), kong.MapperFunc(fdsMapper)),
 	)
 	kctx.FatalIfErrorf(kctx.Run())
 }
@@ -59,29 +71,14 @@ type unmarshaler func([]byte, proto.Message) error
 type marshaler func(proto.Message) ([]byte, error)
 
 func (c *PBConfig) Run() error {
-	if c.Descriptorpb {
-		c.Protoset = &registry.Files{}
-		err := c.Protoset.RegisterFile(descriptorpb.File_google_protobuf_descriptor_proto)
-		if err != nil {
+	c.types = registry.CloneTypes(protoregistry.GlobalTypes)
+	if c.Protoset != nil {
+		if err := registry.AddDynamicTypes(c.types, c.Protoset); err != nil {
 			return err
 		}
-		if c.MessageType != "" && c.In == "" {
-			// shuffle down the args and provide default MessageType
-			c.In = c.MessageType
-			c.MessageType = ""
-		}
-		if c.MessageType == "" {
-			c.MessageType = ".google.protobuf.FileDescriptorSet"
-		}
-		if c.In == "" && c.InFormat == "" {
-			c.InFormat = "pb"
-		}
-	}
-	if c.MessageType == "" {
-		return errors.New(`expected "<message-type>"`)
 	}
 
-	md, err := lookupMessage(c.Protoset, c.MessageType)
+	mt, err := lookupMessage(c.types, c.MessageType)
 	if err != nil {
 		return err
 	}
@@ -93,7 +90,7 @@ func (c *PBConfig) Run() error {
 	if err != nil {
 		return fmt.Errorf("cannot decode %q input: %w", c.inFormat(), err)
 	}
-	message := dynamicpb.NewMessage(md)
+	message := mt.New().Interface()
 	if err := unmarshal(in, message); err != nil {
 		return err
 	}
@@ -111,9 +108,6 @@ func (c *PBConfig) Run() error {
 func (c *PBConfig) AfterApply() error {
 	if c.Zero && c.outFormat() != "json" {
 		return fmt.Errorf(`cannot print zero values with %q, only "json"`, c.outFormat())
-	}
-	if !c.Descriptorpb && c.Protoset == nil {
-		return errors.New(`either "-p/--protoset=PROTOSET" or -D/--descriptorpb required`)
 	}
 	return nil
 }
@@ -142,13 +136,13 @@ func (c *PBConfig) writeOutput(b []byte) error {
 func (c *PBConfig) unmarshaler() (unmarshaler, error) {
 	switch c.inFormat() {
 	case "json":
-		o := protojson.UnmarshalOptions{Resolver: c.Protoset}
+		o := protojson.UnmarshalOptions{Resolver: c.types}
 		return o.Unmarshal, nil
 	case "pb":
-		o := proto.UnmarshalOptions{Resolver: c.Protoset}
+		o := proto.UnmarshalOptions{Resolver: c.types}
 		return o.Unmarshal, nil
 	case "txt":
-		o := prototext.UnmarshalOptions{Resolver: c.Protoset}
+		o := prototext.UnmarshalOptions{Resolver: c.types}
 		return o.Unmarshal, nil
 	}
 	return nil, fmt.Errorf("unknown input format %q", c.inFormat())
@@ -166,7 +160,7 @@ func (c *PBConfig) marshaler() (marshaler, error) {
 	switch c.outFormat() {
 	case "json":
 		o := protojson.MarshalOptions{
-			Resolver:        c.Protoset,
+			Resolver:        c.types,
 			Multiline:       true,
 			EmitUnpopulated: c.Zero,
 		}
@@ -181,7 +175,7 @@ func (c *PBConfig) marshaler() (marshaler, error) {
 		o := proto.MarshalOptions{}
 		return o.Marshal, nil
 	case "txt":
-		o := prototext.MarshalOptions{Resolver: c.Protoset, Multiline: true}
+		o := prototext.MarshalOptions{Resolver: c.types, Multiline: true}
 		return o.Marshal, nil
 	}
 	return nil, fmt.Errorf("unknown output format %s", c.outFormat())
@@ -211,17 +205,20 @@ func canonicalFormat(format string) string {
 	return format
 }
 
-func lookupMessage(reg *registry.Files, name string) (protoreflect.MessageDescriptor, error) {
-	var result []protoreflect.MessageDescriptor
-	reg.RangeFiles(func(fd protoreflect.FileDescriptor) bool {
-		for i := 0; i < fd.Messages().Len(); i++ {
-			md := fd.Messages().Get(i)
-			mds, exactMatch := lookupMessageInMD(md, name)
-			if exactMatch {
-				result = mds
-				return false
-			}
-			result = append(result, mds...)
+func lookupMessage(types *protoregistry.Types, name string) (protoreflect.MessageType, error) {
+	var result []protoreflect.MessageType
+	types.RangeMessages(func(mt protoreflect.MessageType) bool {
+		mdName := string(mt.Descriptor().FullName())
+		if name == mdName || name == "."+mdName {
+			// If we have a full name match, we're done and will also
+			// ignore any other partial name matches.
+			result = []protoreflect.MessageType{mt}
+			return false
+		}
+		mdLowerName := "." + strings.ToLower(mdName)
+		lowerName := strings.ToLower(name)
+		if lowerName == mdLowerName || strings.HasSuffix(mdLowerName, "."+lowerName) {
+			result = append(result, mt)
 		}
 		return true
 	})
@@ -235,57 +232,20 @@ func lookupMessage(reg *registry.Files, name string) (protoreflect.MessageDescri
 	return result[0], nil
 }
 
-func lookupMessageInMD(md protoreflect.MessageDescriptor, name string) (mds []protoreflect.MessageDescriptor, exactMatch bool) {
-	mdName := string(md.FullName())
-	if name == mdName || name == "."+mdName {
-		// If we have a full name match, we're done and will also
-		// ignore any other partial name matches.
-		return []protoreflect.MessageDescriptor{md}, true
-	}
-	mdLowerName := "." + strings.ToLower(mdName)
-	lowerName := strings.ToLower(name)
-	if lowerName == mdLowerName || strings.HasSuffix(mdLowerName, "."+lowerName) {
-		mds = append(mds, md)
-	}
-	subMessages := md.Messages()
-	for i := 0; i < subMessages.Len(); i++ {
-		md = subMessages.Get(i)
-		subMDs, exactMatch := lookupMessageInMD(md, name)
-		if exactMatch {
-			return subMDs, true
-		}
-		mds = append(mds, subMDs...)
-	}
-	return mds, false
-}
-
-func registryMapper(kctx *kong.DecodeContext, target reflect.Value) error {
-	reg, ok := target.Interface().(*registry.Files)
+func fdsMapper(kctx *kong.DecodeContext, target reflect.Value) error {
+	fds, ok := target.Interface().(*descriptorpb.FileDescriptorSet)
 	if !ok {
-		panic("target is not a *registry.Files")
+		panic("target is not a *descriptorpb.FileDescriptorSet")
 	}
 	var filename string
 	if err := kctx.Scan.PopValueInto("file", &filename); err != nil {
 		return err
 	}
-	files, err := registryFiles(filename)
+	b, err := os.ReadFile(filename)
 	if err != nil {
 		return err
 	}
-	*reg = *files
-	return nil
-}
-
-func registryFiles(filename string) (*registry.Files, error) {
-	b, err := os.ReadFile(filename)
-	if err != nil {
-		return nil, err
-	}
-	fds := descriptorpb.FileDescriptorSet{}
-	if err := proto.Unmarshal(b, &fds); err != nil {
-		return nil, err
-	}
-	return registry.NewFiles(&fds)
+	return proto.Unmarshal(b, fds)
 }
 
 func isTTY() bool {

--- a/cmd/pb/main.go
+++ b/cmd/pb/main.go
@@ -94,6 +94,17 @@ func (c *PBConfig) Run() error {
 	if err := unmarshal(in, message); err != nil {
 		return err
 	}
+	if fds, ok := message.(*descriptorpb.FileDescriptorSet); ok {
+		if err := registry.AddDynamicTypes(c.types, fds); err != nil {
+			return err
+		}
+		// Unmarshal again with the input in the resolver registry so
+		// that any exensions defined and used in the input are
+		// unmarshaled properly.
+		if err := unmarshal(in, message); err != nil {
+			return err
+		}
+	}
 	marshal, err := c.marshaler()
 	if err != nil {
 		return err

--- a/cmd/pb/main_test.go
+++ b/cmd/pb/main_test.go
@@ -153,9 +153,29 @@ func TestWellKnown(t *testing.T) {
 	requireJSONFileContent(t, `"10s"`, cli.Out)
 }
 
+func TestFDSInput(t *testing.T) {
+	tmpDir := t.TempDir()
+	cli := PBConfig{
+		Out:         filepath.Join(tmpDir, "out.json"),
+		MessageType: "FileDescriptorSet",
+		In:          "@testdata/options.pb",
+	}
+	require.NoError(t, cli.Run())
+	requireJSONFilesEqual(t, "testdata/golden/TestFDSInput.json", cli.Out)
+}
+
 func requireJSONFileContent(t *testing.T, wantStr string, gotFile string) {
 	t.Helper()
 	b, err := os.ReadFile(gotFile)
 	require.NoError(t, err)
 	require.JSONEq(t, wantStr, string(b))
+}
+
+func requireJSONFilesEqual(t *testing.T, wantFile string, gotFile string) {
+	t.Helper()
+	got, err := os.ReadFile(gotFile)
+	require.NoError(t, err)
+	want, err := os.ReadFile(wantFile)
+	require.NoError(t, err)
+	require.JSONEq(t, string(want), string(got))
 }

--- a/cmd/pb/testdata/golden/TestFDSInput.json
+++ b/cmd/pb/testdata/golden/TestFDSInput.json
@@ -1,0 +1,38 @@
+{
+  "file": [
+    {
+      "name": "options.proto",
+      "dependency": [
+        "google/protobuf/descriptor.proto"
+      ],
+      "messageType": [
+        {
+          "name": "M1",
+          "field": [
+            {
+              "name": "password",
+              "number": 1,
+              "label": "LABEL_OPTIONAL",
+              "type": "TYPE_STRING",
+              "jsonName": "password",
+              "options": {
+                "[redacted]": true
+              }
+            }
+          ]
+        }
+      ],
+      "extension": [
+        {
+          "name": "redacted",
+          "number": 50000,
+          "label": "LABEL_OPTIONAL",
+          "type": "TYPE_BOOL",
+          "extendee": ".google.protobuf.FieldOptions",
+          "jsonName": "redacted"
+        }
+      ],
+      "syntax": "proto3"
+    }
+  ]
+}

--- a/cmd/pb/testdata/options.pb
+++ b/cmd/pb/testdata/options.pb
@@ -1,0 +1,6 @@
+
+ž
+options.proto google/protobuf/descriptor.proto"&
+M1 
+password (	B€µRpassword:;
+redacted.google.protobuf.FieldOptionsÐ† (Rredactedbproto3

--- a/cmd/pb/testdata/options.proto
+++ b/cmd/pb/testdata/options.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+import "google/protobuf/descriptor.proto";
+
+extend google.protobuf.FieldOptions {
+  bool redacted = 50000;
+}
+
+message M1 {
+  string password = 1 [(redacted) = true];
+}

--- a/registry/types.go
+++ b/registry/types.go
@@ -1,0 +1,86 @@
+package registry
+
+import (
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+// CloneTypes returns a clone of the given protoregistry.Types registry.
+// It may panic if any of the messages, enums or extensions in the given
+// registry cannot be added to the clone, however that should never happen.
+func CloneTypes(in *protoregistry.Types) *protoregistry.Types {
+	out := &protoregistry.Types{}
+
+	in.RangeMessages(func(mt protoreflect.MessageType) bool {
+		if err := out.RegisterMessage(mt); err != nil {
+			panic(err)
+		}
+		return true
+	})
+
+	in.RangeEnums(func(et protoreflect.EnumType) bool {
+		if err := out.RegisterEnum(et); err != nil {
+			panic(err)
+		}
+		return true
+	})
+
+	in.RangeExtensions(func(et protoreflect.ExtensionType) bool {
+		if err := out.RegisterExtension(et); err != nil {
+			panic(err)
+		}
+		return true
+	})
+
+	return out
+}
+
+// AddDynamicTypes adds dynamicpb types to the given Types registry for all
+// Messages, Enums and Extensions in the given FileDescriptorSet. If a type
+// already exists in the Types registry, the dynamic type will not be added
+// to replace it, and instead will be ignored.
+func AddDynamicTypes(t *protoregistry.Types, fds *descriptorpb.FileDescriptorSet) error {
+	// FileDescriptor and MessageDescriptor implement the typesContainer interface
+	type typesContainer interface {
+		Messages() protoreflect.MessageDescriptors
+		Enums() protoreflect.EnumDescriptors
+		Extensions() protoreflect.ExtensionDescriptors
+	}
+
+	// addTypes ignores errors from the Types.Register* methods, assuming that
+	// a concrete type is already registered. Concrete types take precedence
+	// over dynamic types as they are compiled into the binary and are more
+	// useful and more easily operated upon.
+	var addTypes func(tc typesContainer)
+	addTypes = func(tc typesContainer) {
+		mds := tc.Messages()
+		for i := 0; i < mds.Len(); i++ {
+			md := mds.Get(i)
+			t.RegisterMessage(dynamicpb.NewMessageType(md)) //nolint:errcheck
+			addTypes(md)
+		}
+
+		enumds := tc.Enums()
+		for i := 0; i < enumds.Len(); i++ {
+			t.RegisterEnum(dynamicpb.NewEnumType(enumds.Get(i))) //nolint:errcheck
+		}
+
+		extds := tc.Extensions()
+		for i := 0; i < extds.Len(); i++ {
+			t.RegisterExtension(dynamicpb.NewExtensionType(extds.Get(i))) //nolint:errcheck
+		}
+	}
+
+	files, err := protodesc.FileOptions{AllowUnresolvable: true}.NewFiles(fds)
+	if err != nil {
+		return err
+	}
+	files.RangeFiles(func(fd protoreflect.FileDescriptor) bool {
+		addTypes(fd)
+		return true
+	})
+	return nil
+}

--- a/registry/types_test.go
+++ b/registry/types_test.go
@@ -1,0 +1,77 @@
+package registry
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	_ "google.golang.org/genproto/googleapis/api/annotations"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/descriptorpb"
+	_ "google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+func TestCloneTypes(t *testing.T) {
+	want := protoregistry.GlobalTypes
+	got := CloneTypes(want)
+	require.Exactly(t, want, got)
+}
+
+func TestAddDynamicTypes(t *testing.T) {
+	fds := newFDS(t)
+
+	types := &protoregistry.Types{}
+	err := AddDynamicTypes(types, fds)
+	require.NoError(t, err)
+
+	// regtest.pb includes descriptor.proto, annotations.proto, http.proto and empty.proto
+	// regtest: 3 messages, 0 enums, 4 extensions
+	// descriptor.proto: 27 messages, 6 enums, 0 extensions
+	// annotations.proto: 0 messages, 0 enums, 1 extension
+	// http.proto: 3 messages, 0 enums, 0 extensions
+	// empty.proto: 1 message, 0 enums, 0 extensions
+	// total: 34 messages, 6 enums, 5 extensions
+	require.Equal(t, 34, types.NumMessages())
+	require.Equal(t, 6, types.NumEnums())
+	require.Equal(t, 5, types.NumExtensions())
+
+	// descriptorpb.FileDescriptorSet should be dynamic as we have only loaded
+	// dynamic messages into the Types registry
+	mt, err := types.FindMessageByName("google.protobuf.FileDescriptorSet")
+	require.NoError(t, err)
+	_, ok := mt.New().Interface().(*dynamicpb.Message)
+	require.True(t, ok, "FileDescriptorSet is not dynamicpb.Message type")
+
+}
+
+func TestAddDynamicTypesKeepsConcrete(t *testing.T) {
+	fds := newFDS(t)
+
+	types := CloneTypes(protoregistry.GlobalTypes)
+	err := AddDynamicTypes(types, fds)
+	require.NoError(t, err)
+
+	// descriptorpb.FileDescriptorSet was imported so should be a concrete type
+	mt, err := types.FindMessageByName("google.protobuf.FileDescriptorSet")
+	require.NoError(t, err)
+	_, ok := mt.New().Interface().(*descriptorpb.FileDescriptorSet)
+	require.True(t, ok, "FileDescriptorSet is not concrete type")
+
+	// regtest.BaseMessage should be dynamic
+	mt, err = types.FindMessageByName("regtest.BaseMessage")
+	require.NoError(t, err)
+	_, ok = mt.New().Interface().(*dynamicpb.Message)
+	require.True(t, ok, "BaseMessage is not dynamicpb.Message type")
+}
+
+func newFDS(t *testing.T) *descriptorpb.FileDescriptorSet {
+	t.Helper()
+	b, err := os.ReadFile("testdata/regtest.pb")
+	require.NoError(t, err)
+	fds := descriptorpb.FileDescriptorSet{}
+	err = proto.Unmarshal(b, &fds)
+	require.NoError(t, err)
+	return &fds
+}


### PR DESCRIPTION
Allow pb to decode well-known message types (including descriptorpb and
pluginpb) without needing a protoset describing them - instead we just
import the generated packages so it they can be used.

This switches to a new registry for types and populates it with
dynamicpb.Messages from the input protoset where there are no concrete
(imported) types already. This makes it easier to know an input is a
FileDescriptorSet through a type assertion rather than needing to use
the protoreflect API.

This removes the `-D` / `--descriptorpb` flag as that is no longer
necessary, as the descriptorpb will be preloaded. However it does mean
that the message type `FileDescriptorSet` will need to be explictly
specfied and the input type of binary proto may need to be specified
too.

For example, the old invocation of:

    protoc -o/dev/stdout foo.proto | pb -D

becomes

    protoc -o/dev/stdout foo.proto | pb -Ip FileDescriptorSet

Some planned changes to auto-detect binary input will allow `-Ip` to be
removed, and to allow message name aliases so `FileDescriptorSet` will
be able to be shortened to `fds`. That would make the pipeline become:

    protoc -o/dev/stdout foo.proto | pb fds

When the input is a FileDescriptorSet, it is loaded into the registry
for decoding messages and extensions and then unmarshaled again. This
allows option extensions defined in the input to be fully decoded and
translated.