### PR TITLE
fix: allow httprule to be forward compatible

### DIFF
--- a/httprule/httprule.go
+++ b/httprule/httprule.go
@@ -57,6 +57,8 @@ func ParseProtoResponse(rule *pb.HttpRule, resp *http.Response, target proto.Mes
 	return nil
 }
 
+var protoJSONUnmarshaller = protojson.UnmarshalOptions{DiscardUnknown: true}
+
 func parseResponseBody(rule *pb.HttpRule, body io.Reader, target proto.Message) error {
 	b, err := io.ReadAll(body)
 	if err != nil {
@@ -74,7 +76,7 @@ func parseResponseBody(rule *pb.HttpRule, body io.Reader, target proto.Message) 
 		}
 	}
 
-	if err := protojson.Unmarshal(b, target); err != nil {
+	if err := protoJSONUnmarshaller.Unmarshal(b, target); err != nil {
 		return fmt.Errorf("protojson unmarshal: %w", err)
 	}
 

--- a/proto/google/protobuf/descriptor.proto
+++ b/proto/google/protobuf/descriptor.proto
@@ -604,11 +604,8 @@ message FieldOptions {
   // check its required fields, regardless of whether or not the message has
   // been parsed.
   //
-  // As of 2021, lazy does no correctness checks on the byte stream during
-  // parsing.  This may lead to crashes if and when an invalid byte stream is
-  // finally parsed upon access.
-  //
-  // TODO(b/211906113):  Enable validation on lazy fields.
+  // As of May 2022, lazy verifies the contents of the byte stream during
+  // parsing.  An invalid byte stream will cause the overall parsing to fail.
   optional bool lazy = 5 [default = false];
 
   // unverified_lazy does no correctness checks on the byte stream. This should


### PR DESCRIPTION
Ignore unknown fields when unmarshaling JSON into protobuf. Without
this, if an upstream proto moves its schema forward, httprule will fail
due to extra fields. Seems like a bizarre default for protojson to be
frank, but here we are.